### PR TITLE
Fix "UID taken" issue with node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 
 FROM node:20-slim
 
+# delete default node user if exists
+# we will likely need his UID
+RUN deluser node || true
+
 # Install required system dependencies
 RUN apt-get update && apt-get install -y \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM node:20-slim
 # delete default node user if exists
 # we will likely need his UID
 RUN deluser node || true
+RUN delgroup node || true
 
 # Install required system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
When I tried to run claude-docker,  I was getting an error

```
Step 7/33 : RUN if getent group $USER_GID > /dev/null 2>&1; then         GROUP_NAME=$(getent group $USER_GID | cut -d: -f1);     else         groupadd -g $USER_GID claude-user && GROUP_NAME=claude-user;     fi &&     useradd -m -s /bin/bash -u $USER_UID -g $GROUP_NAME claude-user &&     echo "claude-user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 ---> Running in 222fc664bdf3
useradd: UID 1000 is not unique
```

Not sure if anyone else has it, maybe it was added in the new node image, or you used it with other UIDs?

This small patch to Dockerfile removes the user if it's there to allow UID=1000 to be taken