### PR TITLE
Fix unbound variable error when ARGS array is empty

### DIFF
--- a/src/claude-docker.sh
+++ b/src/claude-docker.sh
@@ -279,4 +279,4 @@ echo "Starting Claude Code in Docker..."
     -e CLAUDE_CONTINUE_FLAG="$CONTINUE_FLAG" \
     --workdir /workspace \
     --name "claude-docker-$(basename "$CURRENT_DIR")-$$" \
-    claude-docker:latest "${ARGS[@]}"
+    claude-docker:latest ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
Fixed issue where running 'claude' without arguments would fail with:
  "ARGS[@]: unbound variable" error on line 282.

 Changed ${ARGS[@]} to ${ARGS[@]+"${ARGS[@]}"} to properly handle empty array case when set -u is enabled.